### PR TITLE
Change "http://"s to "://"s to avoid contents being blocked

### DIFF
--- a/static/css/main.css
+++ b/static/css/main.css
@@ -1,6 +1,6 @@
 @import url("pygment.css");
-@import url(http://fonts.googleapis.com/css?family=Overlock:400,700,900);
-@import url(http://fonts.googleapis.com/css?family=PT+Mono);
+@import url(//fonts.googleapis.com/css?family=Overlock:400,700,900);
+@import url(//fonts.googleapis.com/css?family=PT+Mono);
 /*
  *  Name: Fresh
  *  Date: February 2013

--- a/static/css/main.scss
+++ b/static/css/main.scss
@@ -9,8 +9,8 @@ $h6size: $h5size * 9/10;
 
 @import url("pygment.css");
 
-@import url(http://fonts.googleapis.com/css?family=Overlock:400,700,900);
-@import url(http://fonts.googleapis.com/css?family=PT+Mono);
+@import url(//fonts.googleapis.com/css?family=Overlock:400,700,900);
+@import url(//fonts.googleapis.com/css?family=PT+Mono);
 
 /*
  *  Name: Fresh

--- a/templates/article.html
+++ b/templates/article.html
@@ -47,7 +47,7 @@
           var disqus_identifier = "{{ article.url }}";
           (function() {
           var dsq = document.createElement('script'); dsq.type = 'text/javascript'; dsq.async = true;
-          dsq.src = 'http://{{ DISQUS_SITENAME }}.disqus.com/embed.js';
+          dsq.src = '//{{ DISQUS_SITENAME }}.disqus.com/embed.js';
           (document.getElementsByTagName('head')[0] || document.getElementsByTagName('body')[0]).appendChild(dsq);
           })();
         </script>

--- a/templates/base.html
+++ b/templates/base.html
@@ -15,8 +15,8 @@
     <title>{% block title %}{{ SITENAME }}{%endblock%}</title>
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
 
-    <link href="http://netdna.bootstrapcdn.com/font-awesome/4.0.3/css/font-awesome.css" rel="stylesheet">
-    <link rel="stylesheet" href="http://netdna.bootstrapcdn.com/twitter-bootstrap/2.3.2/css/bootstrap-combined.min.css" type="text/css" />
+    <link href="//netdna.bootstrapcdn.com/font-awesome/4.0.3/css/font-awesome.css" rel="stylesheet">
+    <link rel="stylesheet" href="//netdna.bootstrapcdn.com/twitter-bootstrap/2.3.2/css/bootstrap-combined.min.css" type="text/css" />
 
     <link rel="stylesheet" href="{{ SITEURL }}/theme/css/main.css" type="text/css" />
     {% if FEED_ALL_ATOM %}
@@ -99,7 +99,7 @@
 {% include 'analytics.html' %}
 {% include 'piwik.html' %}
 {% include 'disqus_script.html' %}
-    <script src="http://code.jquery.com/jquery.min.js"></script>
-    <script src="http://netdna.bootstrapcdn.com/bootstrap/2.3.2/js/bootstrap.min.js"></script>
+    <script src="//code.jquery.com/jquery.min.js"></script>
+    <script src="//netdna.bootstrapcdn.com/bootstrap/2.3.2/js/bootstrap.min.js"></script>
 </body>
 </html>

--- a/templates/disqus_script.html
+++ b/templates/disqus_script.html
@@ -4,7 +4,7 @@
     (function () {
         var s = document.createElement('script'); s.async = true;
         s.type = 'text/javascript';
-        s.src = 'http://' + disqus_shortname + '.disqus.com/count.js';
+        s.src = '//' + disqus_shortname + '.disqus.com/count.js';
         (document.getElementsByTagName('HEAD')[0] || document.getElementsByTagName('BODY')[0]).appendChild(s);
     }());
 </script>


### PR DESCRIPTION
When the page is hosted using `https://` protocol, content transferred through `http://` will be blocked by Chrome (or maybe other browsers as well) for security reasons. So `//` should be used so that the browser will choose the corresponding protocol.
