### PR TITLE
Pages can now be `class=active` in MENU, same behavior as CATEGORIES

### DIFF
--- a/templates/base.html
+++ b/templates/base.html
@@ -50,7 +50,7 @@
                     <div class="navbar-inner">
                         <ul class="nav">
                         {% for title, link in MENUITEMS %}
-                            <li><a href="{{ link }}">{{ title }}</a></li>
+                            <li {% if link[1:] == output_file %}class="active"{% endif %}><a href="{{ link }}">{{ title }}</a></li>
                         {% endfor %}
                         {% if DISPLAY_PAGES_ON_MENU %}
                         {% for pa in PAGES %}


### PR DESCRIPTION
I think it makes more sense this way. You may consider to merge this change.

I am not sure `{% if pa == page %}` is better or worse than `pa.url == page.url` or others.
